### PR TITLE
Fix math module naming conflict

### DIFF
--- a/matcher.py
+++ b/matcher.py
@@ -3,7 +3,7 @@ import math
 import cv2
 import numpy as np
 
-from math import dist
+from math_utils import dist
 
 
 class Matcher:

--- a/math.py
+++ b/math.py
@@ -1,5 +1,0 @@
-import numpy as np
-
-
-def dist(self, p1, p2):
-    return np.sqrt((p1[0] - p2[0]) ** 2 + (p1[1] - p2[1]) ** 2)

--- a/math_utils.py
+++ b/math_utils.py
@@ -1,0 +1,6 @@
+import math
+
+
+def dist(p1, p2):
+    """Calculate Euclidean distance between two 2D points."""
+    return math.sqrt((p1[0] - p2[0]) ** 2 + (p1[1] - p2[1]) ** 2)


### PR DESCRIPTION
## Summary
- avoid conflict with Python's math module by removing `math.py`
- add `math_utils.py` with `dist` helper
- update `matcher.py` to import from `math_utils`

## Testing
- `python -m py_compile bot.py matcher.py app.py main.py math_utils.py`
- `python -m py_compile test-environments/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6863866046388332842fa66c134c1129